### PR TITLE
Fix stale unit tests for curve and superstructure

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,11 @@
 {
+  "java.jdt.ls.java.home": "C:\\Users\\Public\\wpilib\\2026\\jdk",
   "java.configuration.updateBuildConfiguration": "automatic",
   "java.server.launchMode": "Standard",
+  "terminal.integrated.env.windows": {
+    "JAVA_HOME": "C:\\Users\\Public\\wpilib\\2026\\jdk",
+    "PATH": "C:\\Users\\Public\\wpilib\\2026\\jdk\\bin;${env:PATH}"
+  },
   "files.exclude": {
     "**/.git": true,
     "**/.svn": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,6 @@
 {
-  "java.jdt.ls.java.home": "C:\\Users\\Public\\wpilib\\2026\\jdk",
   "java.configuration.updateBuildConfiguration": "automatic",
   "java.server.launchMode": "Standard",
-  "terminal.integrated.env.windows": {
-    "JAVA_HOME": "C:\\Users\\Public\\wpilib\\2026\\jdk",
-    "PATH": "C:\\Users\\Public\\wpilib\\2026\\jdk\\bin;${env:PATH}"
-  },
   "files.exclude": {
     "**/.git": true,
     "**/.svn": true,

--- a/src/test/java/commands/DriveCommandsCurveTest.java
+++ b/src/test/java/commands/DriveCommandsCurveTest.java
@@ -18,10 +18,10 @@ class DriveCommandsCurveTest {
   }
 
   @Test
-  void curve_atHalfDeflection_lessThanHalf() {
+  void curve_atHalfDeflection_greaterThanHalf() {
     double result = DriveCommands.applyCurve(0.5);
-    assertTrue(result < 0.5, "Expected curve output < 0.5 at stick=0.5, got " + result);
-    assertTrue(result > 0.0, "Expected curve output > 0 at stick=0.5");
+    assertTrue(result > 0.5, "Expected curve output > 0.5 at stick=0.5, got " + result);
+    assertTrue(result < 1.0, "Expected curve output < 1.0 at stick=0.5");
   }
 
   @Test

--- a/src/test/java/subsystems/SuperstructureTest.java
+++ b/src/test/java/subsystems/SuperstructureTest.java
@@ -5,10 +5,13 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import edu.wpi.first.hal.HAL;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.units.measure.AngularVelocity;
+import edu.wpi.first.wpilibj.simulation.DriverStationSim;
+import edu.wpi.first.wpilibj.simulation.SimHooks;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.Commands;
 import frc.robot.subsystems.drive.Drive;
@@ -22,6 +25,7 @@ import frc.robot.subsystems.superstructure.Superstructure.WantedState;
 import java.util.function.Supplier;
 import org.ironmaple.simulation.drivesims.SwerveDriveSimulation;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -35,9 +39,17 @@ public class SuperstructureTest {
   Drive mockDrive;
   SwerveDriveSimulation mockDriveSimulation;
 
+  @BeforeAll
+  static void halInit() {
+    HAL.initialize(500, 0);
+  }
+
   @BeforeEach
   @SuppressWarnings("unchecked")
   void setup() {
+    SimHooks.pauseTiming();
+    SimHooks.restartTiming();
+    DriverStationSim.setEnabled(false);
     mockShooter = Mockito.mock(Shooter.class);
     mockHopper = Mockito.mock(Hopper.class);
     mockIntake = Mockito.mock(IntakePivot.class);
@@ -58,6 +70,9 @@ public class SuperstructureTest {
 
     // Default: feeder up to speed (tests that need it false can override per-test)
     when(mockShooter.feederUpToSpeed()).thenReturn(true);
+    when(mockShooter.flywheelUpToSpeed()).thenReturn(true);
+    when(mockShooter.flywheelUpToSpeed(any(AngularVelocity.class))).thenReturn(true);
+    when(mockShooter.getCurrentFlywheelSpeed()).thenReturn(RotationsPerSecond.of(35));
 
     // Default: drive pose/rotation at origin — within the 3.5° hub tolerance
     when(mockDrive.getPose()).thenReturn(new Pose2d());
@@ -72,6 +87,7 @@ public class SuperstructureTest {
   @AfterEach
   void tearDown() {
     CommandScheduler.getInstance().cancelAll();
+    SimHooks.resumeTiming();
     superstructure = null;
   }
 
@@ -150,6 +166,7 @@ public class SuperstructureTest {
     superstructure.currentSuperState = CurrentState.SPINNING_UP;
 
     superstructure.applyStates();
+    superstructure.applyStates();
 
     assertEquals(CurrentState.SHOOTING, superstructure.currentSuperState);
   }
@@ -161,6 +178,7 @@ public class SuperstructureTest {
     superstructure.wantedSuperState = WantedState.PASSING;
     superstructure.currentSuperState = CurrentState.SPINNING_UP;
 
+    superstructure.applyStates();
     superstructure.applyStates();
 
     assertEquals(CurrentState.PASSING, superstructure.currentSuperState);
@@ -201,6 +219,8 @@ public class SuperstructureTest {
 
   @Test
   void idleState_zerosFlywheelWhenHubBecomesInactive() {
+    SimHooks.stepTiming(0.6);
+
     // First loop: hub active → sets wasHubSpinupActive = true
     superstructure.hubSpinupActive = () -> true;
     superstructure.currentSuperState = CurrentState.IDLE;


### PR DESCRIPTION
## Summary
- Update DriveCommandsCurveTest to match current Betaflight curve constants (mid-stick output > 0.5)
- Update SuperstructureTest for 2-loop hub tolerance gating, passing flywheel speed stubs, and hub pre-spin timer behavior

## Test plan
- [ ] `.\gradlew.bat build` passes (including unit tests)